### PR TITLE
Enforcing the name parameter in all agent class creation

### DIFF
--- a/src/chorus/agents/async_tool_chat_agent.py
+++ b/src/chorus/agents/async_tool_chat_agent.py
@@ -50,7 +50,7 @@ class AsyncToolChatAgent(ToolChatAgent):
 
     def __init__(
         self,
-        name: str,
+        name: Optional[str] = None,
         model_name: str = DEFAULT_AGENT_LLM_NAME,
         instruction: Optional[str] = None,
         multi_agent_instruction: Optional[str] = None,

--- a/src/chorus/agents/base.py
+++ b/src/chorus/agents/base.py
@@ -5,7 +5,7 @@ from typing import Optional
 from chorus.config.registrable import Registrable
 from chorus.data.context import AgentContext
 from chorus.data.state import AgentState
-
+from chorus.util.agent_naming import get_unique_agent_name
 
 class Agent(Registrable, metaclass=ABCMeta):
     """Base class for all agents in the Chorus framework.
@@ -14,6 +14,32 @@ class Agent(Registrable, metaclass=ABCMeta):
     It provides basic initialization methods and requires implementing an iterate method
     for the agent's main processing loop.
     """
+    def __init__(self, name: Optional[str] = None):
+        """Initialize a new agent.
+
+        Args:
+            name (str, optional): The name of the agent. If not provided, defaults to None.
+                The name is used to identify and refer to the agent.
+        """
+        if name is None:
+            name = get_unique_agent_name()
+        self._name = name
+    
+    def agent_name(self) -> str:
+        """Get the name of the agent.
+
+        Returns:
+            str: The name of the agent.
+        """
+        return self._name
+    
+    def create_agent_context_id(self) -> str:
+        """Create a unique context ID for the agent.
+
+        Returns:
+            str: An agent context ID.
+        """
+        return self._name
 
     def init_context(self) -> AgentContext:
         """Initialize the agent's context.
@@ -23,7 +49,7 @@ class Agent(Registrable, metaclass=ABCMeta):
         Returns:
             AgentContext: A new context object for this agent.
         """
-        return AgentContext(agent_id=str(id(self)))
+        return AgentContext(agent_id=self.create_agent_context_id())
 
     def init_state(self) -> AgentState:
         """Initialize the agent's state.

--- a/src/chorus/agents/passive_agent.py
+++ b/src/chorus/agents/passive_agent.py
@@ -10,7 +10,6 @@ from chorus.data.agent_status import AgentStatus
 from chorus.data.dialog import Message
 from chorus.data.dialog import Role
 from chorus.data.state import PassiveAgentState
-from chorus.util.agents_util import generate_agent_id
 
 logger = logging.getLogger(__name__)
 
@@ -22,18 +21,17 @@ class PassiveAgent(Agent, metaclass=abc.ABCMeta):
     agents, it does not initiate interactions on its own.
 
     Args:
-        default_agent_id: Optional string ID to use for this agent. If not provided,
-            one will be generated based on the class name.
+        name: Optional name for the agent. If not provided, a default name will be generated.
         no_response_sources: Optional list of source IDs that this agent should ignore
             messages from.
     """
 
     def __init__(
         self,
-        default_agent_id: Optional[str] = None,
+        name: Optional[str] = None,
         no_response_sources: Optional[List[str]] = None,
     ):
-        self._default_agent_id = default_agent_id
+        super().__init__(name)
         self._no_response_sources = no_response_sources
 
     def init_state(self) -> PassiveAgentState:
@@ -43,22 +41,6 @@ class PassiveAgent(Agent, metaclass=abc.ABCMeta):
             PassiveAgentState: A new state object for this passive agent.
         """
         return PassiveAgentState()
-
-    def init_context(self) -> AgentContext:
-        """Initialize the agent's context with an ID.
-
-        Uses the provided default_agent_id if available, otherwise generates one
-        based on the class name.
-
-        Returns:
-            AgentContext: A new context object with the agent's ID.
-        """
-        if self._default_agent_id is not None:
-            agent_id = self._default_agent_id
-        else:
-            agent_id = generate_agent_id(self.__class__.__name__)
-
-        return AgentContext(agent_id=agent_id)
 
     @abc.abstractmethod
     def respond(

--- a/src/chorus/agents/tool_chat_agent.py
+++ b/src/chorus/agents/tool_chat_agent.py
@@ -29,7 +29,7 @@ class ToolChatAgent(PassiveAgent):
     language models and prompters.
 
     Args:
-        name: The name identifier for this agent.
+        name: The name for this agent.
         model_name: The name of the language model to use. Defaults to DEFAULT_AGENT_LLM_NAME.
         instruction: Custom instructions for the agent's behavior. Defaults to None.
         tools: List of executable tools available to the agent. Defaults to None.
@@ -42,7 +42,7 @@ class ToolChatAgent(PassiveAgent):
 
     def __init__(
         self,
-        name: str,
+        name: Optional[str] = None,
         model_name: str = DEFAULT_AGENT_LLM_NAME,
         instruction: Optional[str] = None,
         tools: List[ExecutableTool] = None,
@@ -53,12 +53,11 @@ class ToolChatAgent(PassiveAgent):
         tool_executor_class: Type[SimpleToolExecutor] = SimpleToolExecutor,
         context_switchers: Optional[List[Tuple[MessageTrigger, ChorustionContext]]] = None,
     ):
-        super().__init__(no_response_sources=no_response_sources)
+        super().__init__(name=name, no_response_sources=no_response_sources)
         self._prompter = prompter
         self._planner = planner
         self._tool_executor_class = tool_executor_class
         self._lm = lm
-        self._name = name
         self._tools = tools
         self._model_name = model_name
         self._instruction = instruction

--- a/src/chorus/util/agent_naming.py
+++ b/src/chorus/util/agent_naming.py
@@ -1,0 +1,13 @@
+import uuid
+
+
+def get_unique_agent_name() -> str:
+    """
+    Generate a unique agent name.
+
+    Returns:
+        str: A unique agent name in the format 'agent_<6 hex chars>'
+    """
+    # Generate a random UUID and take first 6 characters of its hex representation
+    unique_id = str(uuid.uuid4()).replace('-', '')[:6]
+    return f"agent_{unique_id}"


### PR DESCRIPTION
Enforcing each single agent to have a name, unify the interface around agent naming