### PR TITLE
fix multiprocessing test on MacOS by set_start_method

### DIFF
--- a/tests/chorus/core/test_chorus_in_thread.py
+++ b/tests/chorus/core/test_chorus_in_thread.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import unittest
 import time
 from unittest.mock import MagicMock
@@ -6,6 +7,8 @@ from chorus.agents import ToolChatAgent, SynchronizedCoordinatorAgent
 from chorus.teams import Team
 from chorus.collaboration import CentralizedCollaboration
 from chorus.helpers.communication import CommunicationHelper
+
+multiprocessing.set_start_method('fork')
 
 class TestChorusInThread(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
On MacOS (and Windows), multiprocessing uses 'spawn', which starts a fresh Python interpreter and needs to pickle (serialize) objects to pass them between processes. Therefore setting the multiprocessing start method to 'fork' can fix the test on MacOS (Note: only works on Unix-like systems).