### PR TITLE
add coverage to pytest; unit test teams module and loading examples

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install hatch mypy
+          pip install -e .[test]  # Install package with test dependencies
           
       - name: Run type checking
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Run Tests with pytest
         run: |
-          python -m pytest -s tests  # Run the tests with pytest using python -m
+          python -m pytest -s tests --cov  # Run the tests with pytest using python -m

--- a/examples/python/agent_triggers.py
+++ b/examples/python/agent_triggers.py
@@ -4,7 +4,6 @@ from chorus.teams import Team
 from chorus.collaboration import CentralizedCollaboration
 from chorus.data.channel import Channel
 from chorus.data.trigger import MessageTrigger
-from chorus.data.dialog import Role
 from chorus.data.context import OrchestrationContext
 from chorus.toolbox import DuckDuckGoWebSearchTool, WebRetrieverTool, SerperWebSearchTool
 from chorus.workspace import NoActivityStopper

--- a/examples/python/multi_agent_workflow.py
+++ b/examples/python/multi_agent_workflow.py
@@ -1,4 +1,4 @@
-from chorus.agents.tool_chat_agent import ConversationalTaskAgent
+from chorus.agents import ConversationalTaskAgent
 from chorus.core import Chorus
 from chorus.toolbox import WebRetrieverTool, DuckDuckGoWebSearchTool
 from chorus.helpers.communication import CommunicationHelper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=7.0.0",
+    "mypy",
+    "hatch",
+    "boto3-stubs",
+    "botocore-stubs",
+    "pytest-cov",
     "requests>=2.31.0",
     "langchain>=0.3.0",
     "langchain-core>=0.3.0",
@@ -40,6 +45,7 @@ test = [
     "llama-index>=0.9.0",
     "llama-index-core>=0.10.0",
     "llama-index-llms-bedrock>=0.1.0",
+    "llama-index-llms-bedrock-converse",
 ]
 
 langchain = [
@@ -125,6 +131,5 @@ requires = [ "hatch-pip-compile" ]
 [tool.hatch.envs.default.scripts]
 typing = [
   "mkdir -p .mypy_cache",
-  "python -m pip install boto3-stubs botocore-stubs llama-index llama-index-core",
   "mypy --install-types --non-interactive src/chorus tests/chorus"
 ]

--- a/src/chorus/teams/services/team_scratchpad.py
+++ b/src/chorus/teams/services/team_scratchpad.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -63,6 +63,10 @@ class TeamScratchpad(TeamService):
                     end_line = action.parameters.get("end_line_number", 0)
                     new_content = action.parameters.get("new_content", "")
                     editor = action.parameters.get("editor", "")
+
+                    if start_line < 0 or end_line < start_line:
+                        observations.append(ObservationData(data={"error": f"Invalid line range: {start_line}-{end_line}"}))
+                        continue
                     
                     if scratchpad_id not in data_store["scratchpads"]:
                         observations.append(ObservationData(data={"error": "Scratchpad not found"}))
@@ -70,6 +74,10 @@ class TeamScratchpad(TeamService):
                         
                     scratchpad = data_store["scratchpads"][scratchpad_id]
                     
+                    if start_line > len(scratchpad):
+                        observations.append(ObservationData(data={"error": f"Start line range out of bounds: {start_line}; scratchpad {scratchpad_id} only has {len(scratchpad)} lines"}))
+                        continue
+
                     # Split content into lines
                     new_lines = new_content.splitlines(keepends=False)
                     new_line_infos = [
@@ -79,6 +87,11 @@ class TeamScratchpad(TeamService):
                             last_modified_time=datetime.now()
                         ) for line in new_lines
                     ]
+                    if len(new_line_infos) != (end_line - start_line + 1):
+                        observations.append(ObservationData(data={"error": f"New content does not match the number of lines to replace: {len(new_line_infos)} vs {(end_line - start_line + 1)}"}))
+                        continue
+
+                    # Update the scratchpad with new lines
                     new_scratchpad = scratchpad[:start_line] + new_line_infos + scratchpad[end_line + 1:]
                     
                     # Insert new lines at the same position

--- a/src/chorus/teams/services/team_voting.py
+++ b/src/chorus/teams/services/team_voting.py
@@ -78,11 +78,16 @@ class TeamVoting(TeamService):
             )
             team_context.message_client.send_message(outbound_event)
 
-    def create_proposal(self, team_context: TeamContext, data_store: Dict, content: str, reasoning: str, proposer: Optional[str] = None) -> Dict:
+    def create_proposal(self, team_context: TeamContext, data_store: Dict, content: str, reasoning: str, proposer: Optional[str]) -> Dict:
         comm = CommunicationHelper(team_context)
-        """Create a new proposal for voting."""
+        """Create a new proposal for voting.
+        
+        NOTE: the proposer is automatically counted as 1 vote for its own proposal
+        """
         if not content:
             return {"error": "Proposal content is required"}
+        if not proposer:
+            return {"error": "Proposer name is required"}
         
         proposal_id = f"proposal_{len(data_store['proposals'])}"
         now = datetime.now()
@@ -126,6 +131,8 @@ class TeamVoting(TeamService):
         """Cast a vote for a proposal."""
         if proposal_id not in data_store["proposals"]:
             return {"error": "Proposal not found"}
+        if not voter:
+            return {"error": "Voter name must be provided"}
         
         proposal = data_store["proposals"][proposal_id]
         if proposal["status"] != "active":
@@ -147,7 +154,6 @@ class TeamVoting(TeamService):
         
         # Record vote as True (in favor)
         data_store["votes"][proposal_id][voter] = True
-        
         # Calculate current results
         votes = data_store["votes"][proposal_id]
         team_info = self.get_team_info()
@@ -272,9 +278,9 @@ class TeamVoting(TeamService):
                 total_required_votes = sum(len(votes) for votes in data_store["votes"].values())
             else:
                 total_required_votes = len(team_info.agent_ids)
-            votes_cast = len(data_store["votes"].get(winning_id, {}))
-            remaining_votes = total_required_votes - votes_cast
-            
+            votes_casted = sum(len(_) for _ in data_store["votes"].values())
+            remaining_votes = total_required_votes - votes_casted
+
             # If second place exists, check if remaining votes could change outcome
             if len(vote_counts) > 1:
                 second_place_votes = vote_counts[1][1]
@@ -282,11 +288,12 @@ class TeamVoting(TeamService):
                     return None
             
             # Return winner if all votes are in or remaining votes can't change outcome
-            if votes_cast == total_required_votes or remaining_votes == 0:
+            if votes_casted == total_required_votes or remaining_votes == 0:
                 return proposals[winning_id]["content"]
             return None
         
-        else:  # Majority vote
+        elif self.decision_making_strategy == DecisionMakingStrategy.MAJORITY_VOTE:
+            # Majority vote
             for proposal_id, proposal in active_proposals.items():
                 proposal_votes = data_store["votes"].get(proposal_id, {})
                 team_info = self.get_team_info()
@@ -298,5 +305,7 @@ class TeamVoting(TeamService):
 
                 if votes_in_favor > total_required_votes / 2:
                     return proposal["content"]
+        else:
+            raise ValueError(f"Unknown decision making strategy: {self.decision_making_strategy}")
 
         return None

--- a/src/chorus/teams/toolbox/team_scratchpad.py
+++ b/src/chorus/teams/toolbox/team_scratchpad.py
@@ -1,13 +1,8 @@
-from typing import List, Optional
-from datetime import datetime
-from datetime import timedelta
-
 from chorus.data import ExecutableTool
 from chorus.data import SimpleExecutableTool
 from chorus.data import ToolSchema
 from chorus.data import Message, EventType
 from chorus.data.data_types import ActionData
-from chorus.helpers import CommunicationHelper
 
 NOT_IN_A_TEAM_ERROR_MESSAGE = "Error: This agent is not part of a team."
 TIMEOUT = 10

--- a/src/chorus/teams/toolbox/team_storage.py
+++ b/src/chorus/teams/toolbox/team_storage.py
@@ -1,6 +1,3 @@
-import os
-from datetime import datetime
-from datetime import timedelta
 from typing import Optional
 
 from chorus.data import ExecutableTool
@@ -8,7 +5,6 @@ from chorus.data import SimpleExecutableTool
 from chorus.data import ToolSchema
 from chorus.data import Message, EventType
 from chorus.data.data_types import ActionData
-from chorus.helpers import CommunicationHelper
 
 NOT_IN_A_TEAM_ERROR_MESSAGE = "Error: This agent is not part of a team."
 TIMEOUT = 10

--- a/src/chorus/teams/toolbox/team_toolbox.py
+++ b/src/chorus/teams/toolbox/team_toolbox.py
@@ -6,7 +6,6 @@ from chorus.data import ToolSchema
 from chorus.data import Message, EventType
 from chorus.data.data_types import ActionData
 from chorus.data.schema import JsonData
-from chorus.helpers import CommunicationHelper
 from chorus.util.async_actions import make_async_observation_data
 
 NOT_IN_A_TEAM_ERROR_MESSAGE = "Error: This agent is not part of a team."

--- a/src/chorus/teams/toolbox/team_voting.py
+++ b/src/chorus/teams/toolbox/team_voting.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional
 from chorus.data.schema import JsonData
 from chorus.data import ExecutableTool
 from chorus.data import SimpleExecutableTool

--- a/src/chorus/teams/toolbox/team_voting.py
+++ b/src/chorus/teams/toolbox/team_voting.py
@@ -13,7 +13,8 @@ TIMEOUT = 10
 class TeamVotingClient(SimpleExecutableTool):
     """A tool for participating in team voting, allowing agents to create proposals and vote on them."""
 
-    def __init__(self):
+    def __init__(self, voter: str):
+        self.voter = voter
         schema = {
             "tool_name": "TeamVotingClient",
             "name": "TeamVotingClient",
@@ -77,6 +78,7 @@ class TeamVotingClient(SimpleExecutableTool):
         context.message_client.send_message(
             Message(
                 event_type=EventType.TEAM_SERVICE,
+                source=self.voter,
                 destination=team_name,
                 actions=[
                     ActionData(
@@ -107,6 +109,7 @@ class TeamVotingClient(SimpleExecutableTool):
         context.message_client.send_message(
             Message(
                 event_type=EventType.TEAM_SERVICE,
+                source=self.voter,
                 destination=team_name,
                 actions=[
                     ActionData(

--- a/tests/chorus/teams/test_team_scratchpad.py
+++ b/tests/chorus/teams/test_team_scratchpad.py
@@ -1,0 +1,150 @@
+import unittest
+from unittest.mock import patch
+
+from chorus.agents.conversational_task_agent import ConversationalTaskAgent
+from chorus.collaboration.centralized import CentralizedCollaboration
+from chorus.teams.agent_team import Team
+from chorus.teams.services.team_scratchpad import TeamScratchpad
+from chorus.teams.toolbox.team_scratchpad import TeamScratchpadClient
+from chorus.util.testing_util import MockMessageClient
+from chorus.data.data_types import ActionData
+
+
+class TestTeamScratchpad(unittest.TestCase):
+    def setUp(self):
+        self.team_scratching_tool_1 = TeamScratchpadClient()
+        self.team_scratching_tool_2 = TeamScratchpadClient()
+        self.team_scratching_tool_3 = TeamScratchpadClient()
+        self.team_scratching_service = TeamScratchpad()
+        self.scratcher_1 = ConversationalTaskAgent(tools=[self.team_scratching_tool_1])
+        self.scratcher_2 = ConversationalTaskAgent(tools=[self.team_scratching_tool_2])
+        self.scratcher_3 = ConversationalTaskAgent(tools=[self.team_scratching_tool_3])
+        self.team = Team(
+            name="ScratchingTeam",
+            agents=[
+                self.scratcher_1,
+                self.scratcher_2,
+                self.scratcher_3,
+            ],
+            collaboration=CentralizedCollaboration(
+                coordinator=self.scratcher_1.get_name()
+            ),
+            services=[
+                self.team_scratching_service
+            ],
+        )
+        self.team_context = self.team.init_context()
+        self.team_state = self.team.init_state()
+        self.team_scratching_tool_1.set_context(self.team_context)
+        self.team_scratching_tool_1._agent_context.message_client = MockMessageClient("VotingTeam")
+        self.team_scratching_tool_2.set_context(self.team_context)
+        self.team_scratching_tool_2._agent_context.message_client = MockMessageClient("VotingTeam")
+        self.team_scratching_tool_3.set_context(self.team_context)
+        self.team_scratching_tool_3._agent_context.message_client = MockMessageClient("VotingTeam")
+
+    def test_scratch(self):
+        with patch.object(self.team_scratching_tool_1._agent_context.message_client, "send_message") as mock_send_message, \
+            patch.object(self.team_scratching_tool_1._agent_context.message_client, "wait_for_response") as mock_wait_for_response:
+            # client create scratchpad
+            print("=== client create scratchpad ===")
+            self.team_scratching_tool_1.create_scratchpad("hello world")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "ScratchingTeam"
+
+            # service create scratchpad
+            print("=== service create scratchpad ===")
+            self.team_scratching_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data == "Created scratchpad hello world"
+
+            # client get scratchpad
+            print("=== client get scratchpad ===")
+            self.team_scratching_tool_2.get_scratchpad("hello world")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "ScratchingTeam"
+            assert message.actions == [ActionData(tool_name='team_scratchpad', action_name='get_scratchpad', parameters={'scratchpad_id': 'hello world'}, tool_use_id=None, async_execution_id=None)]
+
+            # service get scratchpad
+            print("=== service get scratchpad ===")
+            self.team_scratching_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data == {'lines': []}
+
+            # client edit lines
+            print("=== client edit lines ===")
+            self.team_scratching_tool_3.edit_lines("hello world", 0, 0, "foo")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+
+            # service edit lines
+            print("=== service edit lines ===")
+            self.team_scratching_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data == {'message': 'Updated lines 0 to 0', 'lines': ['L0: foo']}
+
+            # another client edit lines
+            print("=== another client edit lines ===")
+            self.team_scratching_tool_3.edit_lines("hello world", 1, 1, "bar")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+
+            # service edit lines
+            print("=== service edit lines ===")
+            self.team_scratching_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data == {'message': 'Updated lines 1 to 1', 'lines': ['L0: foo', 'L1: bar']}
+
+            # client attempt invalid edits
+            print("=== client attempt invalid edits -- negative indices ===")
+            self.team_scratching_tool_1.edit_lines("hello world", -1, 0, "baz")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            self.team_scratching_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert "error" in message.observations[0].data
+
+            print("=== client attempt invalid edits -- end line smaller than start line ===")
+            self.team_scratching_tool_1.edit_lines("hello world", 1, 0, "baz")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            self.team_scratching_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert "error" in message.observations[0].data
+
+            print("=== client attempt invalid edits -- start line out of range ===")
+            self.team_scratching_tool_1.edit_lines("hello world", 3, 3, "baz")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            self.team_scratching_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert "error" in message.observations[0].data
+
+            print("=== client attempt invalid edits -- content line count mismatch ===")
+            self.team_scratching_tool_1.edit_lines("hello world", 0, 1, "baz")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            self.team_scratching_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert "error" in message.observations[0].data
+
+            # delete scratchpad
+            print("=== delete scratchpad ===")
+            self.team_scratching_tool_1.delete_scratchpad("hello world")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "ScratchingTeam"
+            assert message.actions == [ActionData(tool_name='team_scratchpad', action_name='delete_scratchpad', parameters={'scratchpad_id': 'hello world'}, tool_use_id=None, async_execution_id=None)]
+            self.team_scratching_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data == 'Deleted scratchpad hello world'

--- a/tests/chorus/teams/test_team_storage.py
+++ b/tests/chorus/teams/test_team_storage.py
@@ -1,0 +1,144 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from chorus.agents.conversational_task_agent import ConversationalTaskAgent
+from chorus.collaboration.centralized import CentralizedCollaboration
+from chorus.teams.agent_team import Team
+from chorus.teams.services.team_storage import TeamStorage
+from chorus.teams.toolbox.team_storage import TeamStorageClient
+from chorus.util.testing_util import MockMessageClient
+from chorus.data.data_types import ActionData
+
+
+class TestTeamStorage(unittest.TestCase):
+    def setUp(self):
+        self.team_storage_tool_1 = TeamStorageClient()
+        self.team_storage_tool_2 = TeamStorageClient()
+        self.team_storage_tool_3 = TeamStorageClient()
+        self.team_storage_service = TeamStorage()
+        self.scratcher_1 = ConversationalTaskAgent(tools=[self.team_storage_tool_1])
+        self.scratcher_2 = ConversationalTaskAgent(tools=[self.team_storage_tool_2])
+        self.scratcher_3 = ConversationalTaskAgent(tools=[self.team_storage_tool_3])
+        self.team = Team(
+            name="StorageTeam",
+            agents=[
+                self.scratcher_1,
+                self.scratcher_2,
+                self.scratcher_3,
+            ],
+            collaboration=CentralizedCollaboration(
+                coordinator=self.scratcher_1.get_name()
+            ),
+            services=[
+                self.team_storage_service
+            ],
+        )
+        self.team_context = self.team.init_context()
+        self.team_state = self.team.init_state()
+        self.team_storage_tool_1.set_context(self.team_context)
+        self.team_storage_tool_1._agent_context.message_client = MockMessageClient("VotingTeam")
+        self.team_storage_tool_2.set_context(self.team_context)
+        self.team_storage_tool_2._agent_context.message_client = MockMessageClient("VotingTeam")
+        self.team_storage_tool_3.set_context(self.team_context)
+        self.team_storage_tool_3._agent_context.message_client = MockMessageClient("VotingTeam")
+
+    def test_storage(self):
+        with patch.object(self.team_storage_tool_1._agent_context.message_client, "send_message") as mock_send_message, \
+            patch.object(self.team_storage_tool_1._agent_context.message_client, "wait_for_response") as mock_wait_for_response:
+            # client list storage
+            print("=== client list storage ===")
+            self.team_storage_tool_1.list_files()
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "StorageTeam"
+            assert message.actions == [ActionData(tool_name='team_storage', action_name='list_files', parameters={'prefix': None}, tool_use_id=None, async_execution_id=None)]
+
+            # service list storage (empty)
+            print("=== service list storage (empty) ===")
+            self.team_storage_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data == []
+
+            # client write file
+            print("=== client write file ===")
+            self.team_storage_tool_2.write_file(file_path="foo.bar", content="hello world")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "StorageTeam"
+            assert message.actions == [ActionData(tool_name='team_storage', action_name='write_file', parameters={'file_path': 'foo.bar', 'content': 'hello world'}, tool_use_id=None, async_execution_id=None)]
+
+            # service write file
+            print("=== service write file ===")
+            self.team_storage_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data == 'Wrote file foo.bar'
+
+            # another client list storage
+            print("=== another client list storage ===")
+            self.team_storage_tool_3.list_files()
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "StorageTeam"
+            assert message.actions == [ActionData(tool_name='team_storage', action_name='list_files', parameters={'prefix': None}, tool_use_id=None, async_execution_id=None)]
+
+            # service list storage (non-empty)
+            print("=== service list storage (non-empty) ===")
+            self.team_storage_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert len(message.observations[0].data) == 1
+            assert message.observations[0].data[0].endswith("foo.bar")
+            assert os.path.isfile(message.observations[0].data[0])
+            assert open(message.observations[0].data[0]).read() == "hello world"
+
+            # client read file
+            print("=== client read file ===")
+            self.team_storage_tool_1.read_file(file_path="foo.bar")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+
+            # service read file
+            print("=== service read file ===")
+            self.team_storage_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data == 'hello world'
+
+            # client delete file
+            print("=== client delete file ===")
+            self.team_storage_tool_2.delete_file(file_path="foo.bar")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+
+            # service delete file
+            print("=== service delete file ===")
+            self.team_storage_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data == 'Deleted file foo.bar'
+
+            # client attempt invalid read
+            print("=== client attempt invalid read ===")
+            self.team_storage_tool_3.read_file(file_path="foo.bar")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            with self.assertRaises(FileNotFoundError):
+                self.team_storage_service.process_message(self.team_context, self.team_state, message)
+
+            # client list storage
+            print("=== client list storage ===")
+            self.team_storage_tool_1.list_files()
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "StorageTeam"
+            assert message.actions == [ActionData(tool_name='team_storage', action_name='list_files', parameters={'prefix': None}, tool_use_id=None, async_execution_id=None)]
+
+            # service list storage (empty)
+            print("=== service list storage (empty) ===")
+            self.team_storage_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data == []

--- a/tests/chorus/teams/test_team_voting.py
+++ b/tests/chorus/teams/test_team_voting.py
@@ -1,0 +1,402 @@
+import unittest
+from unittest.mock import patch
+
+from chorus.data import EventType
+from chorus.agents.conversational_task_agent import ConversationalTaskAgent
+from chorus.collaboration.centralized import CentralizedCollaboration
+from chorus.teams.agent_team import Team
+from chorus.teams.services.team_voting import TeamVoting
+from chorus.teams.toolbox.team_voting import TeamVotingClient
+from chorus.data.collaboration_strategies import DecisionMakingStrategy
+from chorus.util.testing_util import MockMessageClient
+from chorus.data.data_types import ActionData
+
+
+class TestTeamVoting(unittest.TestCase):
+    def setUp(self):
+        self.team_voting_tool_1 = TeamVotingClient("voter_1")
+        self.team_voting_tool_2 = TeamVotingClient("voter_2")
+        self.team_voting_tool_3 = TeamVotingClient("voter_3")
+        self.team_voting_service = TeamVoting()
+        self.voter_1 = ConversationalTaskAgent(tools=[self.team_voting_tool_1])
+        self.voter_2 = ConversationalTaskAgent(tools=[self.team_voting_tool_2])
+        self.voter_3 = ConversationalTaskAgent(tools=[self.team_voting_tool_3])
+        self.team = Team(
+            name="VotingTeam",
+            agents=[
+                self.voter_1,
+                self.voter_2,
+                self.voter_3,
+            ],
+            collaboration=CentralizedCollaboration(
+                coordinator=self.voter_1.get_name()
+            ),
+            services=[
+                self.team_voting_service
+            ],
+        )
+        self.team_context = self.team.init_context()
+        self.team_state = self.team.init_state()
+        self.team_voting_tool_1.set_context(self.team_context)
+        self.team_voting_tool_1._agent_context.message_client = MockMessageClient("VotingTeam")
+        self.team_voting_tool_2.set_context(self.team_context)
+        self.team_voting_tool_2._agent_context.message_client = MockMessageClient("VotingTeam")
+        self.team_voting_tool_3.set_context(self.team_context)
+        self.team_voting_tool_3._agent_context.message_client = MockMessageClient("VotingTeam")
+
+    def test_majority_vote(self):
+        """Test majority vote -- proposal needs more than 50% of votes"""
+        self.team_voting_service.decision_making_strategy = DecisionMakingStrategy.MAJORITY_VOTE
+        self.team_voting_service.initialize_service(self.team_state)
+        
+        with patch.object(self.team_voting_tool_1._agent_context.message_client, "send_message") as mock_send_message, \
+            patch.object(self.team_voting_tool_1._agent_context.message_client, "wait_for_response") as mock_wait_for_response:
+            # client propose
+            print("=== client propose ===")
+            self.team_voting_tool_1.propose("Let's vote")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="propose",
+                    parameters={"proposal_content": "Let's vote", "reasoning": ""}
+                )
+            ]
+
+            # service create proposal
+            print("=== service create proposal ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data['proposal_id'] == "proposal_0"
+            assert message.observations[0].data['proposal']['id'] == "proposal_0"
+            assert message.observations[0].data['proposal']['content'] == "Let's vote"
+
+            # client list active proposals
+            print("=== client list active proposals ===")
+            self.team_voting_tool_1.list_active_proposals()
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="list_active_proposals",
+                )
+            ]
+
+            # service list active proposals
+            print("=== service list active proposals ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert "proposal_0" in message.observations[0].data['active_proposals']
+            assert message.observations[0].data['active_proposals']["proposal_0"]['id'] == "proposal_0"
+            assert message.observations[0].data['active_proposals']["proposal_0"]['content'] == "Let's vote"
+
+            # client get one proposal
+            print("=== client get one proposal ===")
+            self.team_voting_tool_1.get_proposal("proposal_0")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="get_proposal",
+                    parameters={"proposal_id": "proposal_0"}
+                )
+            ]
+
+            # service get one proposal
+            print("=== service get one proposal ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data['proposal']['id'] == "proposal_0"
+            assert message.observations[0].data['proposal']['content'] == "Let's vote"
+
+            # client vote
+            print("=== client vote ===")
+            self.team_voting_tool_1.vote("proposal_0")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="vote",
+                    parameters={"proposal_id": "proposal_0"}
+                )
+            ]
+            
+            # service cast vote
+            print("=== service cast vote ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data['current_results'] == {'has_majority': False, 'total_votes': 3, 'votes_in_favor': 1}
+
+            # service get decision -- inconclusive
+            print("=== service get decision -- inconclusive ===")
+            decision = self.team_voting_service.get_decision(self.team_state)
+            assert decision == None
+
+            # (another) client vote
+            print("=== (another) client vote ===")
+            self.team_voting_tool_2.vote("proposal_0")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="vote",
+                    parameters={"proposal_id": "proposal_0"}
+                )
+            ]
+
+            # service cast vote
+            print("=== service cast vote ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data['current_results'] == {'has_majority': True, 'total_votes': 3, 'votes_in_favor': 2}
+
+            # service get decision -- majority wins
+            print("=== service get decision -- majority wins ===")
+            decision = self.team_voting_service.get_decision(self.team_state)
+            assert decision == "Let's vote"
+
+    
+    def test_first_come_first_serve_vote(self):
+        """Test first-come-first-serve vote -- first proposal is automatically selected"""
+        self.team_voting_service.decision_making_strategy = DecisionMakingStrategy.FIRST_COME_FIRST_SERVE
+        self.team_voting_service.initialize_service(self.team_state)
+        
+        with patch.object(self.team_voting_tool_1._agent_context.message_client, "send_message") as mock_send_message, \
+            patch.object(self.team_voting_tool_1._agent_context.message_client, "wait_for_response") as mock_wait_for_response:
+            # client propose
+            print("=== client propose ===")
+            self.team_voting_tool_1.propose("Let's vote", "Here's why")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="propose",
+                    parameters={"proposal_content": "Let's vote", "reasoning": "Here's why"}
+                )
+            ]
+
+            # service create proposal
+            print("=== service create proposal ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data['proposal_id'] == "proposal_0"
+            assert message.observations[0].data['proposal']['id'] == "proposal_0"
+            assert message.observations[0].data['proposal']['content'] == "Let's vote"
+            assert message.observations[0].data['proposal']['reasoning'] == "Here's why"
+
+            # client list active proposals
+            print("=== client list active proposals ===")
+            self.team_voting_tool_1.list_active_proposals()
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="list_active_proposals",
+                )
+            ]
+
+            # service list active proposals
+            print("=== service list active proposals ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert "proposal_0" in message.observations[0].data['active_proposals']
+            assert message.observations[0].data['active_proposals']["proposal_0"]['id'] == "proposal_0"
+            assert message.observations[0].data['active_proposals']["proposal_0"]['content'] == "Let's vote"
+            assert message.observations[0].data['active_proposals']["proposal_0"]['reasoning'] == "Here's why"
+
+            # client get one proposal
+            print("=== client get one proposal ===")
+            self.team_voting_tool_1.get_proposal("proposal_0")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="get_proposal",
+                    parameters={"proposal_id": "proposal_0"}
+                )
+            ]
+
+            # service get one proposal
+            print("=== service get one proposal ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data['proposal']['id'] == "proposal_0"
+            assert message.observations[0].data['proposal']['content'] == "Let's vote"
+            assert message.observations[0].data['proposal']['reasoning'] == "Here's why"
+
+            # service get decision
+            print("=== service get decision ===")
+            decision = self.team_voting_service.get_decision(self.team_state)
+            assert decision == "Let's vote"
+
+            # client vote
+            print("=== client vote ===")
+            self.team_voting_tool_2.vote("proposal_0")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="vote",
+                    parameters={"proposal_id": "proposal_0"}
+                )
+            ]
+
+            # service cast vote (not allowed in first-come-first-serve strategy)
+            print("=== service cast vote (not allowed in first-come-first-serve strategy) ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert 'current_results' not in message.observations[0].data
+            assert 'error' in message.observations[0].data
+
+    def test_plurality_vote(self):
+        """Test plurality vote -- proposal with most votes wins"""
+        self.team_voting_service.decision_making_strategy = DecisionMakingStrategy.PLURALITY_VOTE
+        self.team_voting_service.initialize_service(self.team_state)
+        
+        with patch.object(self.team_voting_tool_1._agent_context.message_client, "send_message") as mock_send_message, \
+            patch.object(self.team_voting_tool_1._agent_context.message_client, "wait_for_response") as mock_wait_for_response:
+            # client propose
+            print("=== client propose ===")
+            self.team_voting_tool_1.propose("Let's vote", "Here's why")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="propose",
+                    parameters={"proposal_content": "Let's vote", "reasoning": "Here's why"}
+                )
+            ]
+
+            # service create proposal
+            print("=== service create proposal ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data['proposal_id'] == "proposal_0"
+            assert message.observations[0].data['proposal']['id'] == "proposal_0"
+            assert message.observations[0].data['proposal']['content'] == "Let's vote"
+            assert message.observations[0].data['proposal']['reasoning'] == "Here's why"
+
+            # another client propose
+            print("=== another client propose ===")
+            self.team_voting_tool_2.propose("Let's not vote", "For no reason")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="propose",
+                    parameters={"proposal_content": "Let's not vote", "reasoning": "For no reason"}
+                )
+            ]
+
+            # service create proposal
+            print("=== service create proposal ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data['proposal_id'] == "proposal_1"
+            assert message.observations[0].data['proposal']['id'] == "proposal_1"
+            assert message.observations[0].data['proposal']['content'] == "Let's not vote"
+            assert message.observations[0].data['proposal']['reasoning'] == "For no reason"
+
+            # client list active proposals
+            print("=== client list active proposals ===")
+            self.team_voting_tool_1.list_active_proposals()
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="list_active_proposals",
+                )
+            ]
+
+            # service list active proposals
+            print("=== service list active proposals ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert "proposal_0" in message.observations[0].data['active_proposals']
+            assert message.observations[0].data['active_proposals']["proposal_0"]['id'] == "proposal_0"
+            assert message.observations[0].data['active_proposals']["proposal_0"]['content'] == "Let's vote"
+            assert message.observations[0].data['active_proposals']["proposal_0"]['reasoning'] == "Here's why"
+            assert "proposal_1" in message.observations[0].data['active_proposals']
+            assert message.observations[0].data['active_proposals']["proposal_1"]['id'] == "proposal_1"
+            assert message.observations[0].data['active_proposals']["proposal_1"]['content'] == "Let's not vote"
+            assert message.observations[0].data['active_proposals']["proposal_1"]['reasoning'] == "For no reason"
+
+            # service get decision -- inconclusive
+            print("=== service get decision -- inconclusive ===")
+            decision = self.team_voting_service.get_decision(self.team_state)
+            assert decision == None
+
+            # another client vote
+            print("=== another client vote ===")
+            self.team_voting_tool_3.vote("proposal_1")
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.destination == "VotingTeam"
+            assert message.event_type == EventType.TEAM_SERVICE
+            assert message.actions == [
+                ActionData(
+                    tool_name="team_voting",
+                    action_name="vote",
+                    parameters={"proposal_id": "proposal_1"}
+                )
+            ]
+
+            # service cast vote
+            print("=== service cast vote ===")
+            self.team_voting_service.process_message(self.team_context, self.team_state, message)
+            message = mock_send_message.call_args[0][0]
+            print(message)
+            assert message.observations[0].data['current_results'] == {'is_leading': True, 'total_votes': 3, 'votes_in_favor': 2}
+
+            # service get decision
+            print("=== service get decision ===")
+            decision = self.team_voting_service.get_decision(self.team_state)
+            assert decision == "Let's not vote"

--- a/tests/chorus/test_examples.py
+++ b/tests/chorus/test_examples.py
@@ -1,0 +1,9 @@
+import unittest
+import os
+
+class TestExamples(unittest.TestCase):
+    def test_example_importable(self):
+        for example_path in os.listdir("examples/python/"):
+            print(f"Testing example {example_path}")
+            with open(f"examples/python/{example_path}") as f:
+                exec(f.read(), {})


### PR DESCRIPTION
- Enable coverage report in pytest
- Unit test loading scripts in `examples/python/`; fix misc import errors.
- Unit test team voting, scratchpad and storage tools and services; boosted overall coverage from <50% to 50%:
```
src/chorus/teams/services/team_scratchpad.py                         80     11     36     10    80%
src/chorus/teams/services/team_storage.py                            57      5     22      7    85%
src/chorus/teams/services/team_voting.py                            171     23    100     32    80%
......
src/chorus/teams/toolbox/team_scratchpad.py                          61     12     24     12    72%
src/chorus/teams/toolbox/team_storage.py                             57     10     20     10    74%
src/chorus/teams/toolbox/team_voting.py                              63     12     24     12    72%
```
- Address team voting bugs:
  - In `create_proposal`, `proposer` should be required to case default vote
  - In `cast_vote`, `voter` should be required for counting votes
  - For plurality vote, `votes_cast(ed)` should be sum of total votes, not only the `winning_id`'s votes